### PR TITLE
Pass api_token to hipchat_url

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,4 +17,4 @@ Suggests:
     testthatsomemore,
     withr
 LazyData: true
-RoxygenNote: 5.0.1
+RoxygenNote: 5.0.1.9000

--- a/R/history.R
+++ b/R/history.R
@@ -14,6 +14,7 @@
 #' @param full logical. Whether or not to display full history. By default, \code{FALSE},
 #'   which will return a \code{data.frame} with columns \code{c('id', 'from', 'message', 'date')}.
 #'   If \code{full = TRUE}, the raw output from the Hipchat API is provided as a list.
+#' @param api_token character. By default, \code{\link{hipchat_api_token}()}.
 #' @return If \code{full = FALSE} (the default), a \code{data.frame}
 #'   with columns \code{c('id', 'from', 'message', 'time', 'color')}. Otherwise, a full list
 #'   of the JSON response from the Hipchat API. (see References section)
@@ -29,8 +30,8 @@
 #'   # Full Hipchat API output for the latest 75 messages.
 #' }
 hipchat_history <- function(room_name_or_id, date = 'recent', timezone = 'UTC', start_index = 0,
-                            max_results = 100, reverse = TRUE, full = FALSE) {
-  room_id <- sanitize_room(room_name_or_id)
+                            max_results = 100, reverse = TRUE, full = FALSE, api_token = hipchat_api_token()) {
+  room_id <- sanitize_room(room_name_or_id, api_token = api_token)
   date <- sanitize_date(date)
   stopifnot(is.character(timezone) && length(timezone) == 1)
   stopifnot(is.numeric(start_index) &&  length(start_index) == 1 && start_index >= 0)

--- a/R/message.R
+++ b/R/message.R
@@ -96,6 +96,7 @@ hipchat <- function(room_or_user, message, notify = TRUE, color = 'yellow',
 #'   room IDs are preferred to room names). The \code{type} key will
 #'   contain one of \code{c("room", "user")} according as \code{room_or_user}
 #'   is determined to be a room or user.
+#' @inheritParams hipchat
 #' @examples
 #' stopifnot(hipchat:::determine_target('some@@guy.com')$type == 'user')
 #'

--- a/R/message.R
+++ b/R/message.R
@@ -73,7 +73,7 @@ hipchat <- function(room_or_user, message, notify = TRUE, color = 'yellow',
   }
 
   # We are sending a message to one room/user that is under 10,000 characters.
-  target <- determine_target(room_or_user)
+  target <- determine_target(room_or_user, api_token = api_token)
   if (target$type == 'user')
     hipchat_send('user', target$target, 'message', message = message,
                  notify = notify, message_format = message_format, api_token = api_token)
@@ -103,7 +103,7 @@ hipchat <- function(room_or_user, message, notify = TRUE, color = 'yellow',
 #'   stopifnot(is.numeric(hipchat:::determine_target('Some room')$target))
 #'   # Will be a room ID, assuming "Some room" exists.
 #' }
-determine_target <- function(room_or_user) {
+determine_target <- function(room_or_user, api_token = hipchat_api_token()) {
   stopifnot(is.character(room_or_user) || is.numeric(room_or_user)) 
   stopifnot(length(room_or_user) == 1)
 
@@ -116,7 +116,7 @@ determine_target <- function(room_or_user) {
     room_or_user <- if (grepl('^[0-9]+$', room_or_user))
       as.integer(room_or_user)
     else {
-      out <- unname(hipchat_room_id(room_or_user))
+      out <- unname(hipchat_room_id(room_or_user, api_token))
       if (is.na(room_or_user)) stop("Hipchat room %s not found", sQuote(room_or_user))
       out
     }

--- a/R/room.R
+++ b/R/room.R
@@ -87,13 +87,14 @@ room_cache <- local({
 #'
 #' @param room_name_or_id character or integer.
 #' @param topic character. Must be under 250 characters.
+#' @param api_token character. By default, \code{\link{hipchat_api_token}()}.
 #' @export
 #' @examples
 #' \dontrun{
 #'   hipchat_topic('Some room', 'This is the new topic')
 #' }
-hipchat_topic <- function(room_name_or_id, topic) {
-  room_name_or_id <- sanitize_room(room_name_or_id)
+hipchat_topic <- function(room_name_or_id, topic, api_token = hipchat_api_token()) {
+  room_name_or_id <- sanitize_room(room_name_or_id, api_token = api_token)
   topic <- sanitize_topic(topic)
 
   hipchat_send('room', room_name_or_id, 'topic', topic = topic)
@@ -109,6 +110,7 @@ hipchat_topic <- function(room_name_or_id, topic) {
 #'   (beginning with an @@) of the room's owner. Defaults to the current user. (Optional)
 #' @param privacy character. Whether the room is available for access by other users or not.
 #'   Must be either \code{'public'} or \code{'private'} (default is \code{'public'}).
+#' @param api_token character. By default, \code{\link{hipchat_api_token}()}.
 #' @return the id of the newly created room.
 #' @export
 #' @examples
@@ -116,8 +118,8 @@ hipchat_topic <- function(room_name_or_id, topic) {
 #'   hipchat_create_room('A new private room', 'With a new topic', privacy = 'private')
 #' }
 hipchat_create_room <- function(room_name, topic = NULL, guest_access = FALSE,
-  owner_user, privacy = 'public') {
-  room_name <- sanitize_room(room_name, convert_to_id = FALSE)
+  owner_user, privacy = 'public', api_token = hipchat_api_token()) {
+  room_name <- sanitize_room(room_name, convert_to_id = FALSE, api_token = api_token)
   stopifnot(is.character(room_name))
   if (nchar(room_name) > 100)
     stop("Hipchat rooms can be at most 100 characters, you provided ", nchar(room_name))
@@ -140,6 +142,7 @@ hipchat_create_room <- function(room_name, topic = NULL, guest_access = FALSE,
 #' @param confirm logical. Whether or not to ask for a confirmation message
 #'   before deleting the room. By default, \code{TRUE}. (Deleting rooms
 #'   is dangerous!)
+#' @param api_token character. By default, \code{\link{hipchat_api_token}()}.
 #' @return \code{TRUE} or \code{FALSE} according as the room was deleted.
 #' @examples
 #' \dontrun{
@@ -147,8 +150,8 @@ hipchat_create_room <- function(room_name, topic = NULL, guest_access = FALSE,
 #'    hipchat_delete_room('Example room') # Will ask a confirmation message.
 #'    hipchat_delete_room('Example room', confirm = FALSE) # Dangerous! No confirmation.
 #' }
-hipchat_delete_room <- function(room_name_or_id, confirm = TRUE) {
-  room_id <- sanitize_room(room_name_or_id)
+hipchat_delete_room <- function(room_name_or_id, confirm = TRUE, api_token = api_token) {
+  room_id <- sanitize_room(room_name_or_id, api_token = api_token)
 
   if (isTRUE(confirm)) {
     confirm <- sample(c('OK', 'Yes', 'Y', 'Confirm'), 1)

--- a/R/room.R
+++ b/R/room.R
@@ -13,6 +13,7 @@
 #' @param full logical. Whether or not to return raw output from the Hipchat
 #'   API. If \code{FALSE} (the default), only a named character vector of
 #'   room IDs will be returned.
+#' @param api_token character. By default, \code{\link{hipchat_api_token}()}.
 #' @export
 #' @references https://www.hipchat.com/docs/apiv2/method/get_all_rooms
 #' @return an integer vector, with names being room names and values being room IDs
@@ -38,6 +39,7 @@ hipchat_rooms <- function(max_results = 1000, include_archived = FALSE, full = F
 #'
 #' @param room_name character. A character vector giving the room
 #'   name. This is vectorized if you would like IDs for multiple rooms.
+#' @param api_token character. By default, \code{\link{hipchat_api_token}()}.
 #' @return A named integer vector, with the names being the room names
 #'   and the values being the room IDs. If a room ID is not found, the
 #'   value returned will be NA, so that if you pass in one room name
@@ -45,11 +47,11 @@ hipchat_rooms <- function(max_results = 1000, include_archived = FALSE, full = F
 #' @note This will call the hipchat API at \code{https://api.hipchat.com/v2/room}
 #'   to fetch the room-id map.
 #' @export
-hipchat_room_id <- function(room_name) {
+hipchat_room_id <- function(room_name, api_token = hipchat_api_token()) {
   stopifnot(is.character(room_name))
 
   room_in_cache <- function(room_name) is.element(room_name, room_cache$getNames())
-  if (any(!room_in_cache(room_name))) refresh_room_cache()
+  if (any(!room_in_cache(room_name))) refresh_room_cache(api_token)
 
   setNames(room_cache$get(room_name) %||% NA_character_, room_name)
 }

--- a/R/send.R
+++ b/R/send.R
@@ -41,7 +41,7 @@
 hipchat_send <- function(type, var, ..., api_token = hipchat_api_token(), method = 'GET') {
   tryCatch(
     expr = {
-      url <- if (missing(var)) hipchat_url(type, ...) else hipchat_url(type, var, ...)
+      url <- if (missing(var)) hipchat_url(type, api_token = api_token, ...) else hipchat_url(type, api_token = api_token, var, ...)
       named <- function(x) nzchar(names(x) %||% rep("", length(x)))
       params <- list(...)
       params <- params[named(params)]

--- a/R/user.R
+++ b/R/user.R
@@ -34,7 +34,6 @@ hipchat_create_user <- function(name, password, email, title, mention_name,
                  is_group_admin = is_group_admin, timezone = timezone, method = 'POST')
   if (!missing(title)) params$title <- title
   if (!missing(mention_name)) params$mention_name <- mention_name
-  browser()
   do.call(hipchat_send, params)
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -38,7 +38,7 @@ comma <- function(x, sep = " and ") {
   else paste(paste(head(x, -1), collapse = ", "), utils::tail(x, 1), sep = sep)
 }
 
-sanitize_room <- function(room_name_or_id, convert_to_id = TRUE) {
+sanitize_room <- function(room_name_or_id, convert_to_id = TRUE, api_token = hipchat_api_token()) {
   if (!is.numeric(room_name_or_id) && !is.character(room_name_or_id))
     stop("Please provide a room name or ID to set a room; got something ",
          "of class ", class(room_name_or_id)[1])
@@ -46,7 +46,7 @@ sanitize_room <- function(room_name_or_id, convert_to_id = TRUE) {
 
   if (!isTRUE(convert_to_id)) return(room_name_or_id)
   if (is.character(room_name_or_id)) room_name_or_id <- local({
-    out <- hipchat_room_id(room_name_or_id)
+    out <- hipchat_room_id(room_name_or_id, api_token)
     if (is.na(out)) stop("No Hipchat room ", sQuote(room_name_or_id), " found.")
     out
   }) else room_name_or_id

--- a/man/determine_target.Rd
+++ b/man/determine_target.Rd
@@ -4,7 +4,7 @@
 \alias{determine_target}
 \title{Determine whether we are sending to a room or user.}
 \usage{
-determine_target(room_or_user)
+determine_target(room_or_user, api_token = hipchat_api_token())
 }
 \arguments{
 \item{room_or_user}{character or integer}

--- a/man/determine_target.Rd
+++ b/man/determine_target.Rd
@@ -8,6 +8,11 @@ determine_target(room_or_user, api_token = hipchat_api_token())
 }
 \arguments{
 \item{room_or_user}{character or integer}
+
+\item{api_token}{character. Optional API token. The default is 
+\code{hipchat:::hipchat_api_token()}, which uses
+ the environment variable \code{HIPCHAT_API_TOKEN} or the 
+ R option \code{getOption('hipchat.api_token')} if they are present.}
 }
 \value{
 a list with two keys, \code{target} and \code{type}.

--- a/man/hipchat_create_room.Rd
+++ b/man/hipchat_create_room.Rd
@@ -5,7 +5,7 @@
 \title{Create a new Hipchat room. (Must have privileges)}
 \usage{
 hipchat_create_room(room_name, topic = NULL, guest_access = FALSE,
-  owner_user, privacy = "public")
+  owner_user, privacy = "public", api_token = hipchat_api_token())
 }
 \arguments{
 \item{room_name}{character. Room name. Maximum 100 characters.}
@@ -20,6 +20,8 @@ By default, \code{FALSE}.}
 
 \item{privacy}{character. Whether the room is available for access by other users or not.
 Must be either \code{'public'} or \code{'private'} (default is \code{'public'}).}
+
+\item{api_token}{character. By default, \code{\link{hipchat_api_token}()}.}
 }
 \value{
 the id of the newly created room.

--- a/man/hipchat_delete_room.Rd
+++ b/man/hipchat_delete_room.Rd
@@ -4,7 +4,7 @@
 \alias{hipchat_delete_room}
 \title{Delete a Hipchat room.}
 \usage{
-hipchat_delete_room(room_name_or_id, confirm = TRUE)
+hipchat_delete_room(room_name_or_id, confirm = TRUE, api_token = api_token)
 }
 \arguments{
 \item{room_name_or_id}{character or integer.}
@@ -12,6 +12,8 @@ hipchat_delete_room(room_name_or_id, confirm = TRUE)
 \item{confirm}{logical. Whether or not to ask for a confirmation message
 before deleting the room. By default, \code{TRUE}. (Deleting rooms
 is dangerous!)}
+
+\item{api_token}{character. By default, \code{\link{hipchat_api_token}()}.}
 }
 \value{
 \code{TRUE} or \code{FALSE} according as the room was deleted.

--- a/man/hipchat_history.Rd
+++ b/man/hipchat_history.Rd
@@ -5,7 +5,8 @@
 \title{Show the history for a given Hipchat room.}
 \usage{
 hipchat_history(room_name_or_id, date = "recent", timezone = "UTC",
-  start_index = 0, max_results = 100, reverse = TRUE, full = FALSE)
+  start_index = 0, max_results = 100, reverse = TRUE, full = FALSE,
+  api_token = hipchat_api_token())
 }
 \arguments{
 \item{room_name_or_id}{character or integer.}
@@ -28,6 +29,8 @@ The default is \code{TRUE}, but set this to \code{FALSE} for consistent paging.}
 \item{full}{logical. Whether or not to display full history. By default, \code{FALSE},
 which will return a \code{data.frame} with columns \code{c('id', 'from', 'message', 'date')}.
 If \code{full = TRUE}, the raw output from the Hipchat API is provided as a list.}
+
+\item{api_token}{character. By default, \code{\link{hipchat_api_token}()}.}
 }
 \value{
 If \code{full = FALSE} (the default), a \code{data.frame}

--- a/man/hipchat_room_id.Rd
+++ b/man/hipchat_room_id.Rd
@@ -4,11 +4,13 @@
 \alias{hipchat_room_id}
 \title{Convert a Hipchat room name to an ID.}
 \usage{
-hipchat_room_id(room_name)
+hipchat_room_id(room_name, api_token = hipchat_api_token())
 }
 \arguments{
 \item{room_name}{character. A character vector giving the room
 name. This is vectorized if you would like IDs for multiple rooms.}
+
+\item{api_token}{character. By default, \code{\link{hipchat_api_token}()}.}
 }
 \value{
 A named integer vector, with the names being the room names

--- a/man/hipchat_topic.Rd
+++ b/man/hipchat_topic.Rd
@@ -4,12 +4,14 @@
 \alias{hipchat_topic}
 \title{Change the topic of a room.}
 \usage{
-hipchat_topic(room_name_or_id, topic)
+hipchat_topic(room_name_or_id, topic, api_token = hipchat_api_token())
 }
 \arguments{
 \item{room_name_or_id}{character or integer.}
 
 \item{topic}{character. Must be under 250 characters.}
+
+\item{api_token}{character. By default, \code{\link{hipchat_api_token}()}.}
 }
 \description{
 Change the topic of a room.

--- a/man/match_method.Rd
+++ b/man/match_method.Rd
@@ -11,7 +11,7 @@ match_method(url)
 }
 \value{
 character vector of applicable methods, from
-   \code{c("GET", "POST", "PUT", "DELETE"}.
+   \code{c("GET", "POST", "PUT", "DELETE")}.
 }
 \description{
 Find appropriate HTTP method for a given Hipchat URL.


### PR DESCRIPTION
I just barely started poking around here but I'm pretty sure we need to pass this bad boy into hipchat_url (because it pulls from hipchat_api_token here: https://github.com/robertzk/hipchat/blob/master/R/send.R#L89)...  401 statuses errrrryday, son.